### PR TITLE
CMakeLists.txt: Added missing instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ include_directories(include/)
 
 # Get all source files
 file(GLOB SOURCES "src/*.c" "src/*.cpp")
-link_directories(${CMAKE_INSTALL_PREFIX}/lib)
 
 # Add target
 add_library(eiiutils SHARED ${SOURCES})


### PR DESCRIPTION
Added missing instruction while resolving conflicts
of 3.0 PR that got merged with master

Signed-off-by: Vinod K B <vinod.k.b@intel.com>